### PR TITLE
feat: Dispose, removal of event_date and event_timestamp, added profile_number in common params

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ await statsigStrategy.initialize();
 
 // This will be validated against the SESSION_START schema
 statsigStrategy.track(EventNames.SESSION_START, {
-  event_date: '20240315',
-  event_timestamp: 1710633600000,
+  profile_number: 123,
   cr_user_id: 'user123',
   ftm_language: 'en_US',
   version_number: '1.2.3',
@@ -146,21 +145,26 @@ await statsigStrategy.initialize();
 
 // This will be validated against your custom SESSION_START schema
 statsigStrategy.track(EventNames.SESSION_START, {
-  event_date: '20240315',
+  profile_number: 123,
+  cr_user_id: 'user123',
+  ftm_language: 'en_US',
+  version_number: '1.2.3',
+  json_version_number: '2.0.0',
+  days_since_last: 2,
   custom_field: 'my-value'
 });
 ```
 
 # Other Use Cases
 ## A single strategy trigger
-```
+```ts
 const firebaseStrategy = analytics.getRegistry('firebase');
 firebaseStrategy.track('test', { test: 'test' });
 ```
 
 ## A custom strategy
 Make sure to extend the abstract strategy to making sure all necessary implementations are present.
-```
+```ts
 import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
 
 export class CustomStrategy extends AbstractAnalyticsStrategy {
@@ -181,6 +185,35 @@ analytics.register('custom', customStrategy);
 analytics.track('test', { foo: 'baz' });
 ```
 
+# Resource Cleanup (`v1.3.0+`)
+Both Firebase and Statsig strategies provide a `dispose` method to properly clean up resources when they are no longer needed. This is particularly important to prevent memory leaks and ensure proper shutdown of connections.
+
+`dispose` has been added in version `1.3.0`.
+
+## Firebase Strategy
+```ts
+const firebaseStrategy = new FirebaseStrategy({
+  // ... configuration ...
+});
+
+// When done with the strategy
+firebaseStrategy.dispose();  // This will delete the Firebase app instance if it exists
+```
+
+## Statsig Strategy
+```ts
+const statsigStrategy = new StatsigStrategy({
+  // ... configuration ...
+});
+
+// When done with the strategy
+statsigStrategy.dispose();  // This will shut down the Statsig client if it exists
+```
+
+It's recommended to call `dispose()` when:
+- Your application is shutting down
+- You're switching to a different analytics strategy
+- You need to reinitialize the strategy with different configuration
 
 # Caveats
 We are leaving the configuration option definition on the consuming app layer since we may want to have different buckets or measurement ids for these apps.

--- a/src/event-schemas.ts
+++ b/src/event-schemas.ts
@@ -34,8 +34,7 @@ export const EventNames = {
 
 // Base event schema with fields common to all events
 const baseEventSchema = z.object({
-  event_date: requiredDate('Event date'),
-  event_timestamp: requiredNumber('Event timestamp'),
+  profile_number: requiredNumber('Profile number'),
   cr_user_id: requiredString('CR User ID'),
   ftm_language: requiredString('Language'),
   version_number: requiredString('Version number'),

--- a/src/strategies/abstract-strategy.ts
+++ b/src/strategies/abstract-strategy.ts
@@ -6,6 +6,28 @@
  * for specific analytics providers like Firebase, Statsig etc.
  */
 export abstract class AbstractAnalyticsStrategy {
+
+  /**
+   * Initialize the strategy
+   * This method is called when the strategy is created and should be used 
+   * to initialize the strategy.
+   * @returns A promise that resolves when the strategy is initialized.
+   */
   abstract initialize(): Promise<void>;
+
+  /**
+   * Track an event
+   * This method is called to track an event.
+   * @param eventName The name of the event to track.
+   * @param data The data to track.
+   */
   abstract track(eventName: string, data: any): void;
+
+  /**
+   * Dispose the strategy
+   * This method is called when the strategy is no longer needed and should be used
+   * to dispose the strategy.
+   */
+  abstract dispose(): void;
+
 }

--- a/src/strategies/firebase-strategy/firebase-strategy.spec.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.spec.ts
@@ -2,6 +2,10 @@ import { FirebaseStrategy } from './firebase-strategy';
 import * as firebaseDefaults from 'firebase/app';
 import * as firebaseAnalyticsDefaults from 'firebase/analytics';
 
+// Mock modules first
+jest.mock('firebase/app');
+jest.mock('firebase/analytics');
+
 const MOCK_OPTIONS = {
   userProperties: {
     userID: 'mock-user-id'
@@ -10,35 +14,71 @@ const MOCK_OPTIONS = {
 };
 
 describe('FirebaseStrategy', () => {
-  describe('Given MOCK_OPTIONS options', () => {
-    const strategy = new FirebaseStrategy(MOCK_OPTIONS);
+  let strategy: FirebaseStrategy;
+  let mockFirebaseApp: any;
+  let mockAnalytics: any;
 
-    describe('When initialized', () => {
-      it('should call initializeApp()', async () => {
-        const spy = jest.spyOn(firebaseDefaults, 'initializeApp')
-        await strategy.initialize();
-        expect(spy).toHaveBeenCalled();
-      });
+  beforeEach(() => {
+    // Initialize mocks
+    mockFirebaseApp = {};
+    mockAnalytics = {};
 
-      it('should call getAnalytics()', async () => {
-        const spy = jest.spyOn(firebaseAnalyticsDefaults, 'getAnalytics');
-        await strategy.initialize();
-        expect(spy).toHaveBeenCalled();
-      });
+    // Setup mock implementations
+    (firebaseDefaults.initializeApp as jest.Mock).mockReturnValue(mockFirebaseApp);
+    (firebaseDefaults.deleteApp as jest.Mock).mockResolvedValue(undefined);
+    (firebaseAnalyticsDefaults.getAnalytics as jest.Mock).mockReturnValue(mockAnalytics);
+    (firebaseAnalyticsDefaults.logEvent as jest.Mock).mockImplementation(() => {});
+    (firebaseAnalyticsDefaults.setUserProperties as jest.Mock).mockImplementation(() => {});
 
-      it('should call setUserProperties()', async () => {
-        const spy = jest.spyOn(firebaseAnalyticsDefaults, 'setUserProperties');
-        await strategy.initialize();
-        expect(spy).toHaveBeenCalled();
-      });
+    // Reset all mocks
+    jest.clearAllMocks();
+    
+    strategy = new FirebaseStrategy(MOCK_OPTIONS);
+  });
+
+  describe('When initialized', () => {
+    it('should call initializeApp()', async () => {
+      const spy = jest.spyOn(firebaseDefaults, 'initializeApp');
+      await strategy.initialize();
+      expect(spy).toHaveBeenCalled();
     });
 
-    describe('When track() is invoked', () => {
-      it('should call logEvent()', () => {
-        const spy = jest.spyOn(firebaseAnalyticsDefaults, 'logEvent');
-        strategy.track('mock-event', {});
-        expect(spy).toHaveBeenCalled();
-      });
+    it('should call getAnalytics()', async () => {
+      const spy = jest.spyOn(firebaseAnalyticsDefaults, 'getAnalytics');
+      await strategy.initialize();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should call setUserProperties()', async () => {
+      const spy = jest.spyOn(firebaseAnalyticsDefaults, 'setUserProperties');
+      await strategy.initialize();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('When track() is invoked', () => {
+    it('should call logEvent()', async () => {
+      await strategy.initialize();
+      const spy = jest.spyOn(firebaseAnalyticsDefaults, 'logEvent');
+      strategy.track('mock-event', {});
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('When dispose() is called', () => {
+    it('should call deleteApp() if firebaseApp exists', async () => {
+      await strategy.initialize();
+      const spy = jest.spyOn(firebaseDefaults, 'deleteApp');
+      strategy.dispose();
+      expect(spy).toHaveBeenCalledWith(mockFirebaseApp);
+    });
+
+    it('should not call deleteApp() if firebaseApp does not exist', () => {
+      // Create a new strategy without initializing it
+      const uninitializedStrategy = new FirebaseStrategy(MOCK_OPTIONS);
+      const spy = jest.spyOn(firebaseDefaults, 'deleteApp');
+      uninitializedStrategy.dispose();
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/strategies/firebase-strategy/firebase-strategy.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.ts
@@ -1,19 +1,21 @@
-import { AbstractAnalyticsStrategy } from '../abstract-strategy';
-import { FirebaseApp, FirebaseOptions, initializeApp } from 'firebase/app';
-import { Analytics, getAnalytics, logEvent, setUserProperties} from 'firebase/analytics';
+import { AbstractAnalyticsStrategy } from "../abstract-strategy";
+import { FirebaseApp, FirebaseOptions, initializeApp, deleteApp } from "firebase/app";
+import { Analytics, getAnalytics, logEvent, setUserProperties } from "firebase/analytics";
 
 export interface FirebaseStrategyOptions {
   firebaseOptions: FirebaseOptions;
   userProperties: any;
 }
 
+/**
+ * Firebase Strategy Class Definition
+ * This class is used to track events using Firebase Analytics.
+ */
 export class FirebaseStrategy extends AbstractAnalyticsStrategy {
   firebaseApp: FirebaseApp;
   analytics: Analytics;
 
-  constructor(
-    private options: FirebaseStrategyOptions
-  ) {
+  constructor(private options: FirebaseStrategyOptions) {
     super();
   }
 
@@ -24,12 +26,18 @@ export class FirebaseStrategy extends AbstractAnalyticsStrategy {
       this.analytics = getAnalytics(this.firebaseApp);
       setUserProperties(this.analytics, userProperties, { global: true });
     } catch (error) {
-      console.error('Error while initializing Firebase:', error);
+      console.error("Error while initializing Firebase:", error);
       throw error;
     }
   }
 
   track(eventName: string, params: any): void {
     logEvent(this.analytics, eventName, params);
+  }
+
+  dispose(): void {
+    if (this.firebaseApp) {
+      deleteApp(this.firebaseApp);
+    }
   }
 }

--- a/src/strategies/statsig-strategy/statsig-strategy.spec.ts
+++ b/src/strategies/statsig-strategy/statsig-strategy.spec.ts
@@ -14,11 +14,13 @@ const MOCK_OPTIONS = {
 // Mock StatsigClient
 const mockLogEvent = jest.fn();
 const mockInitializeAsync = jest.fn();
+const mockShutdown = jest.fn();
 
 jest.mock('@statsig/js-client', () => ({
   StatsigClient: jest.fn().mockImplementation(() => ({
     logEvent: mockLogEvent,
-    initializeAsync: mockInitializeAsync
+    initializeAsync: mockInitializeAsync,
+    shutdown: mockShutdown
   }))
 }));
 
@@ -28,6 +30,7 @@ describe('StatsigStrategy', () => {
   beforeEach(async () => {
     mockLogEvent.mockClear();
     mockInitializeAsync.mockClear();
+    mockShutdown.mockClear();
     strategy = new StatsigStrategy(MOCK_OPTIONS);
     await strategy.initialize();
   });
@@ -41,8 +44,7 @@ describe('StatsigStrategy', () => {
   describe('Common field validation across all events', () => {
     it('should fail validation for missing cr_user_id consistently', () => {
       const baseIncompleteEvent = {
-        event_date: '20240315',
-        event_timestamp: 1710633600000,
+        profile_number: 123,
         ftm_language: 'en_US',
         version_number: '1.2.3',
         json_version_number: '2.0.0'
@@ -70,8 +72,7 @@ describe('StatsigStrategy', () => {
     describe('session_start', () => {
       it('should validate successful session_start event', () => {
         const validEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -93,8 +94,7 @@ describe('StatsigStrategy', () => {
 
       it('should fail validation for missing days_since_last', () => {
         const invalidEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -118,8 +118,7 @@ describe('StatsigStrategy', () => {
     describe('session_end', () => {
       it('should validate successful session_end event', () => {
         const validEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -141,8 +140,7 @@ describe('StatsigStrategy', () => {
 
       it('should fail validation for missing duration', () => {
         const invalidEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -168,8 +166,7 @@ describe('StatsigStrategy', () => {
     describe('puzzle_completed', () => {
       it('should validate successful puzzle_completed event', () => {
         const validEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -197,8 +194,7 @@ describe('StatsigStrategy', () => {
 
       it('should fail validation for missing puzzle fields', () => {
         const invalidEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -224,8 +220,7 @@ describe('StatsigStrategy', () => {
     describe('selected_level', () => {
       it('should validate successful selected_level event', () => {
         const validEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -247,8 +242,7 @@ describe('StatsigStrategy', () => {
 
       it('should fail validation for missing level_selected', () => {
         const invalidEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -272,8 +266,7 @@ describe('StatsigStrategy', () => {
     describe('level_completed', () => {
       it('should validate successful level_completed event', () => {
         const validEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -298,8 +291,7 @@ describe('StatsigStrategy', () => {
 
       it('should fail validation for missing level completion fields', () => {
         const invalidEvent = {
-          event_date: '20240315',
-          event_timestamp: 1710633600000,
+          profile_number: 123,
           cr_user_id: 'user123',
           ftm_language: 'en_US',
           version_number: '1.2.3',
@@ -324,8 +316,7 @@ describe('StatsigStrategy', () => {
   describe('When tracking download_25 event', () => {
     it('should validate successful download_25 event', () => {
       const validEvent = {
-        event_date: '20240315',
-        event_timestamp: 1710633600000,
+        profile_number: 123,
         cr_user_id: 'user123',
         ftm_language: 'en_US',
         version_number: '1.2.3',
@@ -347,8 +338,7 @@ describe('StatsigStrategy', () => {
 
     it('should fail validation for missing required fields', () => {
       const incompleteEvent = {
-        event_date: '20240315',
-        event_timestamp: 1710633600000
+        profile_number: 123
       };
 
       strategy.track(EventNames.DOWNLOAD_25, incompleteEvent);
@@ -362,6 +352,19 @@ describe('StatsigStrategy', () => {
           reason: expect.stringMatching(/CR User ID is required|Language is required|Version number is required|JSON version number is required|Milliseconds since session start is required/)
         }
       });
+    });
+  });
+
+  describe('When dispose() is called', () => {
+    it('should call shutdown() if client exists', () => {
+      strategy.dispose();
+      expect(mockShutdown).toHaveBeenCalled();
+    });
+
+    it('should not call shutdown() if client does not exist', () => {
+      const newStrategy = new StatsigStrategy(MOCK_OPTIONS);
+      newStrategy.dispose();
+      expect(mockShutdown).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/strategies/statsig-strategy/statsig-strategy.ts
+++ b/src/strategies/statsig-strategy/statsig-strategy.ts
@@ -1,8 +1,8 @@
-import { AbstractAnalyticsStrategy } from '../abstract-strategy';
-import { StatsigClient, StatsigOptions, StatsigUser } from '@statsig/js-client';
-import { StatsigAutoCapturePlugin } from '@statsig/web-analytics';
-import { z } from 'zod';
-import { DefaultEventSchemas } from '../../event-schemas';
+import { AbstractAnalyticsStrategy } from "../abstract-strategy";
+import { StatsigClient, StatsigOptions, StatsigUser } from "@statsig/js-client";
+import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
+import { z } from "zod";
+import { DefaultEventSchemas } from "../../event-schemas";
 
 export interface StatsigStrategyOptions {
   clientKey: string;
@@ -13,20 +13,22 @@ export interface StatsigStrategyOptions {
   debug?: boolean; // Add debug mode option
 }
 
+/**
+ * Statsig Strategy Class Definition
+ * This class is used to track events using Statsig.
+ */
 export class StatsigStrategy extends AbstractAnalyticsStrategy {
   client: StatsigClient;
   private eventSchemas: Record<string, z.ZodSchema<any>>;
   private debug: boolean;
 
-  constructor(
-    private options: StatsigStrategyOptions
-  ) {
+  constructor(private options: StatsigStrategyOptions) {
     super();
     this.debug = options.debug ?? false;
     // Merge default schemas with custom schemas, custom schemas take precedence
     this.eventSchemas = {
       ...DefaultEventSchemas,
-      ...options.customEventSchemas
+      ...options.customEventSchemas,
     };
   }
 
@@ -35,12 +37,12 @@ export class StatsigStrategy extends AbstractAnalyticsStrategy {
       const { clientKey, statsigUser, statsigOptions } = this.options;
       const optionsWithAutoCapture = {
         ...statsigOptions,
-        plugins: [new StatsigAutoCapturePlugin()]
-      }
+        plugins: [new StatsigAutoCapturePlugin()],
+      };
       this.client = new StatsigClient(clientKey, statsigUser, optionsWithAutoCapture);
       await this.client.initializeAsync();
     } catch (e) {
-      console.error('Error initializing statsig client. ', e);
+      console.error("Error initializing statsig client. ", e);
       throw e;
     }
   }
@@ -61,11 +63,11 @@ export class StatsigStrategy extends AbstractAnalyticsStrategy {
         isValid = false;
         // Use Zod's formatted error messages
         validationReason = result.error.issues
-          .map(issue => {
-            const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : '';
+          .map((issue) => {
+            const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
             return `${path}${issue.message}`;
           })
-          .join('; ');
+          .join("; ");
       } else {
         finalParams = result.data; // Use validated data
       }
@@ -75,7 +77,7 @@ export class StatsigStrategy extends AbstractAnalyticsStrategy {
     const enrichedParams = {
       ...finalParams,
       is_valid: isValid,
-      ...(validationReason && { reason: validationReason })
+      ...(validationReason && { reason: validationReason }),
     };
 
     // Extract value and metadata for Statsig's format
@@ -83,7 +85,13 @@ export class StatsigStrategy extends AbstractAnalyticsStrategy {
     this.client.logEvent({
       eventName,
       value,
-      metadata
+      metadata,
     });
+  }
+
+  dispose(): void {
+    if (this.client) {
+      this.client.shutdown();
+    }
   }
 }


### PR DESCRIPTION
# Changes
- Removed `event_date` and `event_timestamp` from base event schema
- Added `profile_number` as a required field to base event schema
- Implemented `dispose()` method for both Firebase and Statsig strategies
  - Firebase: Calls `deleteApp(firebaseApp)` when app exists
  - Statsig: Calls `client.shutdown()` when client exists
- Updated unit tests to reflect schema changes and test dispose functionality
- Added documentation section in README about resource cleanup

# How to test
- Run `npm test` to verify all tests pass
- Check that tracking events requires `profile_number` and no longer requires `event_date`/`event_timestamp`
- Verify `dispose()` properly cleans up resources for both strategies

Ref: [AJ-363](https://curiouslearning.atlassian.net/browse/AJ-363)


[AJ-363]: https://curiouslearning.atlassian.net/browse/AJ-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ