### PR TITLE
fix: added firebase app name when initializing firebase

### DIFF
--- a/src/strategies/firebase-strategy/firebase-strategy.spec.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.spec.ts
@@ -7,6 +7,7 @@ jest.mock('firebase/app');
 jest.mock('firebase/analytics');
 
 const MOCK_OPTIONS = {
+  firebaseName: 'mock-firebase',
   userProperties: {
     userID: 'mock-user-id'
   },

--- a/src/strategies/firebase-strategy/firebase-strategy.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.ts
@@ -3,7 +3,7 @@ import { FirebaseApp, FirebaseOptions, initializeApp, deleteApp } from "firebase
 import { Analytics, getAnalytics, logEvent, setUserProperties } from "firebase/analytics";
 
 export interface FirebaseStrategyOptions {
-  firebaseName?: string;
+  firebaseName: string;
   firebaseOptions: FirebaseOptions;
   userProperties: any;
 }

--- a/src/strategies/firebase-strategy/firebase-strategy.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.ts
@@ -3,6 +3,7 @@ import { FirebaseApp, FirebaseOptions, initializeApp, deleteApp } from "firebase
 import { Analytics, getAnalytics, logEvent, setUserProperties } from "firebase/analytics";
 
 export interface FirebaseStrategyOptions {
+  firebaseName?: string;
   firebaseOptions: FirebaseOptions;
   userProperties: any;
 }
@@ -21,8 +22,8 @@ export class FirebaseStrategy extends AbstractAnalyticsStrategy {
 
   async initialize() {
     try {
-      const { firebaseOptions, userProperties } = this.options;
-      this.firebaseApp = initializeApp(firebaseOptions);
+      const { firebaseOptions, userProperties, firebaseName } = this.options;
+      this.firebaseApp = initializeApp(firebaseOptions, firebaseName);
       this.analytics = getAnalytics(this.firebaseApp);
       setUserProperties(this.analytics, userProperties, { global: true });
     } catch (error) {

--- a/src/strategies/firebase-strategy/firebase-strategy.ts
+++ b/src/strategies/firebase-strategy/firebase-strategy.ts
@@ -23,6 +23,10 @@ export class FirebaseStrategy extends AbstractAnalyticsStrategy {
   async initialize() {
     try {
       const { firebaseOptions, userProperties, firebaseName } = this.options;
+      if (!firebaseName?.trim()) {
+        throw new Error("FirebaseStrategyOptions.firebaseName must be a non-empty string.");
+      }
+      
       this.firebaseApp = initializeApp(firebaseOptions, firebaseName);
       this.analytics = getAnalytics(this.firebaseApp);
       setUserProperties(this.analytics, userProperties, { global: true });


### PR DESCRIPTION
# Changes
- added additional required parameter in FirebaseStrategyOptions

# How to test
- Updating other projects require name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firebase strategy supports named instances to manage multiple Firebase configurations concurrently.
* **Bug Fixes**
  * Initialization now validates the instance name and provides clearer error messaging when missing or invalid.
* **Tests**
  * Unit tests adjusted to reflect the new instance-name requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->